### PR TITLE
Fix unique timestamp

### DIFF
--- a/.github/actions/collect_data/src/parsers/python_unittest_parser.py
+++ b/.github/actions/collect_data/src/parsers/python_unittest_parser.py
@@ -57,7 +57,9 @@ def get_tests(test_report_path):
             for testcase in testcases:
                 message = None
                 test_start_ts = testcase.get("@timestamp", previous_test_end_ts)
-                duration = testcase["@time"]
+                duration = float(testcase["@time"])
+                if duration == 0:
+                    duration = 0.01
                 skipped = testcase.get("skipped", False)
                 error = testcase.get("error", False)
                 failure = testcase.get("failure", False)

--- a/.github/actions/collect_data/src/utils.py
+++ b/.github/actions/collect_data/src/utils.py
@@ -45,7 +45,7 @@ def parse_timestamp(timestamp):
 
 
 def get_data_pipeline_datetime_from_datetime(requested_datetime):
-    return requested_datetime.strftime("%Y-%m-%dT%H:%M:%S%z")
+    return requested_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
 
 
 def get_pipeline_row_from_github_info(github_runner_environment, github_pipeline_json, github_jobs_json):


### PR DESCRIPTION
It can happen that tt-mlir test can have duration zero which can cause problems when generating test timestamps.
In the long run we should move to pytests instead of unittest, and log test start, end and duration

- Print milliseconds in timestamp
- If test duration is 0 set it to 0.01