### PR TITLE
Change to model name instead of model id for ShieldBenchmarkDataMapper

### DIFF
--- a/.github/actions/collect_data/src/benchmark.py
+++ b/.github/actions/collect_data/src/benchmark.py
@@ -192,7 +192,7 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
         for benchmark in benchmarks:
             if metadata:
                 logger.debug(f"Processing benchmark with metadata included...")
-                benchmark = {**metadata, **benchmark}  # benchmark values take precedence
+                benchmark = {**benchmark, **metadata}  # metadata values take precedence
             measurements = self._create_measurements(
                 job,
                 "benchmark",
@@ -244,7 +244,7 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
         for benchmark in benchmarks_summary:
             if metadata:
                 logger.debug(f"Processing benchmark summary with metadata included...")
-                benchmark = {**metadata, **benchmark}  # benchmark values take precedence
+                benchmark = {**benchmark, **metadata}  # metadata values take precedence
             measurements = self._create_measurements(
                 job,
                 "benchmark_summary",

--- a/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574878586/report_40574878586.json
+++ b/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574878586/report_40574878586.json
@@ -2,6 +2,7 @@
     "benchmarks": [
         {
             "timestamp": "2025-04-15_22-43-31",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -26,6 +27,7 @@
         },
         {
             "timestamp": "2025-04-15_22-44-05",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -50,6 +52,7 @@
         },
         {
             "timestamp": "2025-04-15_22-45-33",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -74,6 +77,7 @@
         },
         {
             "timestamp": "2025-04-15_22-45-59",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -98,6 +102,7 @@
         },
         {
             "timestamp": "2025-04-15_22-46-26",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -122,6 +127,7 @@
         },
         {
             "timestamp": "2025-04-15_22-46-53",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -146,6 +152,7 @@
         },
         {
             "timestamp": "2025-04-15_22-47-22",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -170,6 +177,7 @@
         },
         {
             "timestamp": "2025-04-15_22-48-01",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -194,6 +202,7 @@
         },
         {
             "timestamp": "2025-04-15_22-48-50",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -218,6 +227,7 @@
         },
         {
             "timestamp": "2025-04-15_22-49-56",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -242,6 +252,7 @@
         },
         {
             "timestamp": "2025-04-15_22-50-52",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -266,6 +277,7 @@
         },
         {
             "timestamp": "2025-04-15_22-52-40",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -290,6 +302,7 @@
         },
         {
             "timestamp": "2025-04-15_22-53-52",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -314,6 +327,7 @@
         },
         {
             "timestamp": "2025-04-15_22-56-04",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -338,6 +352,7 @@
         },
         {
             "timestamp": "2025-04-15_22-57-08",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -362,6 +377,7 @@
         },
         {
             "timestamp": "2025-04-15_22-58-32",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -386,6 +402,7 @@
         },
         {
             "timestamp": "2025-04-15_22-59-56",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -410,6 +427,7 @@
         },
         {
             "timestamp": "2025-04-15_23-02-12",
+            "model_name": "meta-llama/Llama-3.2-1B-Instruct",
             "model_id": "meta-llama/Llama-3.2-1B-Instruct",
             "backend": "vllm",
             "device": "t3k",

--- a/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574879252/report_40574879252.json
+++ b/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574879252/report_40574879252.json
@@ -2,6 +2,7 @@
     "benchmarks": [
         {
             "timestamp": "2025-04-15_23-14-55",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -26,6 +27,7 @@
         },
         {
             "timestamp": "2025-04-15_23-15-37",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -50,6 +52,7 @@
         },
         {
             "timestamp": "2025-04-15_23-17-46",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -74,6 +77,7 @@
         },
         {
             "timestamp": "2025-04-15_23-18-23",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -98,6 +102,7 @@
         },
         {
             "timestamp": "2025-04-15_23-19-01",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -122,6 +127,7 @@
         },
         {
             "timestamp": "2025-04-15_23-19-40",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -146,6 +152,7 @@
         },
         {
             "timestamp": "2025-04-15_23-20-22",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -170,6 +177,7 @@
         },
         {
             "timestamp": "2025-04-15_23-21-17",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -194,6 +202,7 @@
         },
         {
             "timestamp": "2025-04-15_23-22-27",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -218,6 +227,7 @@
         },
         {
             "timestamp": "2025-04-15_23-24-13",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -242,6 +252,7 @@
         },
         {
             "timestamp": "2025-04-15_23-25-34",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -266,6 +277,7 @@
         },
         {
             "timestamp": "2025-04-15_23-28-16",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -290,6 +302,7 @@
         },
         {
             "timestamp": "2025-04-15_23-30-22",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -314,6 +327,7 @@
         },
         {
             "timestamp": "2025-04-15_23-33-51",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -338,6 +352,7 @@
         },
         {
             "timestamp": "2025-04-15_23-35-42",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -362,6 +377,7 @@
         },
         {
             "timestamp": "2025-04-15_23-38-21",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -386,6 +402,7 @@
         },
         {
             "timestamp": "2025-04-15_23-41-04",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -410,6 +427,7 @@
         },
         {
             "timestamp": "2025-04-15_23-45-22",
+            "model_name": "meta-llama/Llama-3.2-3B-Instruct",
             "model_id": "meta-llama/Llama-3.2-3B-Instruct",
             "backend": "vllm",
             "device": "t3k",

--- a/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574879934/report_40574879934.json
+++ b/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574879934/report_40574879934.json
@@ -2,6 +2,7 @@
     "benchmarks": [
         {
             "timestamp": "2025-04-15_21-22-27",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -26,6 +27,7 @@
         },
         {
             "timestamp": "2025-04-15_21-23-10",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -50,6 +52,7 @@
         },
         {
             "timestamp": "2025-04-15_21-25-22",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -74,6 +77,7 @@
         },
         {
             "timestamp": "2025-04-15_21-26-00",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -98,6 +102,7 @@
         },
         {
             "timestamp": "2025-04-15_21-26-39",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -122,6 +127,7 @@
         },
         {
             "timestamp": "2025-04-15_21-27-20",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -146,6 +152,7 @@
         },
         {
             "timestamp": "2025-04-15_21-28-06",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -170,6 +177,7 @@
         },
         {
             "timestamp": "2025-04-15_21-29-07",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -194,6 +202,7 @@
         },
         {
             "timestamp": "2025-04-15_21-30-28",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -218,6 +227,7 @@
         },
         {
             "timestamp": "2025-04-15_21-32-39",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -242,6 +252,7 @@
         },
         {
             "timestamp": "2025-04-15_21-34-02",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -266,6 +277,7 @@
         },
         {
             "timestamp": "2025-04-15_21-36-49",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -290,6 +302,7 @@
         },
         {
             "timestamp": "2025-04-15_21-39-33",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -314,6 +327,7 @@
         },
         {
             "timestamp": "2025-04-15_21-43-19",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -338,6 +352,7 @@
         },
         {
             "timestamp": "2025-04-15_21-45-48",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -362,6 +377,7 @@
         },
         {
             "timestamp": "2025-04-15_21-49-33",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -386,6 +402,7 @@
         },
         {
             "timestamp": "2025-04-15_21-53-22",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -410,6 +427,7 @@
         },
         {
             "timestamp": "2025-04-15_21-59-50",
+            "model_name": "meta-llama/Llama-3.1-8B-Instruct",
             "model_id": "meta-llama/Llama-3.1-8B-Instruct",
             "backend": "vllm",
             "device": "t3k",

--- a/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574880532.json
+++ b/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574880532.json
@@ -2,6 +2,7 @@
     "benchmarks": [
         {
             "timestamp": "2025-04-15_16-18-39",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -26,6 +27,7 @@
         },
         {
             "timestamp": "2025-04-15_16-19-40",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -50,6 +52,7 @@
         },
         {
             "timestamp": "2025-04-15_16-23-17",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -74,6 +77,7 @@
         },
         {
             "timestamp": "2025-04-15_16-24-15",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -98,6 +102,7 @@
         },
         {
             "timestamp": "2025-04-15_16-25-18",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -122,6 +127,7 @@
         },
         {
             "timestamp": "2025-04-15_16-26-22",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -146,6 +152,7 @@
         },
         {
             "timestamp": "2025-04-15_16-27-33",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -170,6 +177,7 @@
         },
         {
             "timestamp": "2025-04-15_16-29-03",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -194,6 +202,7 @@
         },
         {
             "timestamp": "2025-04-15_16-30-58",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -218,6 +227,7 @@
         },
         {
             "timestamp": "2025-04-15_16-34-01",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -242,6 +252,7 @@
         },
         {
             "timestamp": "2025-04-15_16-35-24",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -266,6 +277,7 @@
         },
         {
             "timestamp": "2025-04-15_16-39-34",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -290,6 +302,7 @@
         },
         {
             "timestamp": "2025-04-15_16-42-09",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -314,6 +327,7 @@
         },
         {
             "timestamp": "2025-04-15_16-47-22",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -338,6 +352,7 @@
         },
         {
             "timestamp": "2025-04-15_16-49-34",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -362,6 +377,7 @@
         },
         {
             "timestamp": "2025-04-15_16-52-44",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -386,6 +402,7 @@
         },
         {
             "timestamp": "2025-04-15_16-55-55",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -410,6 +427,7 @@
         },
         {
             "timestamp": "2025-04-15_17-01-07",
+            "model_name": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "model_id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
             "backend": "vllm",
             "device": "t3k",

--- a/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574881066.json
+++ b/.github/actions/collect_data/test/data/14468030535/artifacts/report_40574881066.json
@@ -2,6 +2,7 @@
     "benchmarks": [
         {
             "timestamp": "2025-04-15_11-29-46",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -26,6 +27,7 @@
         },
         {
             "timestamp": "2025-04-15_11-31-48",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -50,6 +52,7 @@
         },
         {
             "timestamp": "2025-04-15_11-39-42",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -74,6 +77,7 @@
         },
         {
             "timestamp": "2025-04-15_11-41-47",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -98,6 +102,7 @@
         },
         {
             "timestamp": "2025-04-15_11-44-02",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -122,6 +127,7 @@
         },
         {
             "timestamp": "2025-04-15_11-46-30",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -146,6 +152,7 @@
         },
         {
             "timestamp": "2025-04-15_11-49-07",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -170,6 +177,7 @@
         },
         {
             "timestamp": "2025-04-15_11-52-38",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -194,6 +202,7 @@
         },
         {
             "timestamp": "2025-04-15_11-57-46",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -218,6 +227,7 @@
         },
         {
             "timestamp": "2025-04-15_12-06-21",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -242,6 +252,7 @@
         },
         {
             "timestamp": "2025-04-15_12-10-02",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -266,6 +277,7 @@
         },
         {
             "timestamp": "2025-04-15_12-19-25",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -290,6 +302,7 @@
         },
         {
             "timestamp": "2025-04-15_12-30-05",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -314,6 +327,7 @@
         },
         {
             "timestamp": "2025-04-15_12-43-56",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -338,6 +352,7 @@
         },
         {
             "timestamp": "2025-04-15_12-56-35",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -362,6 +377,7 @@
         },
         {
             "timestamp": "2025-04-15_13-12-39",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -386,6 +402,7 @@
         },
         {
             "timestamp": "2025-04-15_13-28-47",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",
@@ -410,6 +427,7 @@
         },
         {
             "timestamp": "2025-04-15_13-59-14",
+            "model_name": "meta-llama/Llama-3.1-70B-Instruct",
             "model_id": "meta-llama/Llama-3.1-70B-Instruct",
             "backend": "vllm",
             "device": "t3k",

--- a/.github/actions/collect_data/test/test_benchmark_mapper.py
+++ b/.github/actions/collect_data/test/test_benchmark_mapper.py
@@ -40,6 +40,7 @@ def test_process_benchmarks(mapper, pipeline):
         "benchmarks": [
             {
                 "device": "test_device",
+                "model_name": "test_model",
                 "model_id": "test_model",
                 "input_sequence_length": 128,
                 "output_sequence_length": 128,
@@ -58,7 +59,8 @@ def test_process_benchmarks_with_metadata(mapper, pipeline):
     report_data = {
         "metadata": {
             "report_id": "test_report",
-            "model_id": "test_model",
+            "model_name": "test_model",
+            "model_id": "id_test_spec_test_model_test_device",
             "inference_engine": "vllm",
         },
         "benchmarks": [
@@ -105,19 +107,19 @@ def test_no_job_found(mapper, pipeline):
 
 
 def test_format_model_name(mapper):
-    benchmark = {"model_id": "Llama-3.2-1B"}
+    benchmark = {"model_name": "Llama-3.2-1B"}
     result = mapper._format_model_name(benchmark)
     assert result == "Llama-3.2-1B"
 
 
 def test_format_model_name_with_prefix(mapper):
-    benchmark = {"model_id": "meta-llama/Llama-3.2-1B"}
+    benchmark = {"model_name": "meta-llama/Llama-3.2-1B"}
     result = mapper._format_model_name(benchmark)
     assert result == "Llama-3.2-1B"
 
 
 def test_format_model_name_none(mapper):
-    benchmark = {"model_id": None}
+    benchmark = {"model_name": None}
     result = mapper._format_model_name(benchmark)
     assert result is None
 


### PR DESCRIPTION
This PR adds changes relevant to processing of benchmarks and benchmark summary fields and takes model_name instead of model_id for consistency.