### PR TITLE
ai_summary/run: Document job-level continue-on-error

### DIFF
--- a/.github/actions/ai_summary/run/Readme.md
+++ b/.github/actions/ai_summary/run/Readme.md
@@ -10,6 +10,10 @@ posts it to Slack.
 ai-run-summary:
   needs: [generate-matrix, your-matrix-job]
   if: always()
+  # Best-effort job: never flip the workflow result red. Step-level
+  # continue-on-error only protects the action call — checkout failure,
+  # `Show report`, etc. would still bubble up without this.
+  continue-on-error: true
   runs-on: ubuntu-latest
   steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` at the job level in the usage example so future callers don't inherit the gap that step-level `continue-on-error` doesn't cover `checkout`/post-render steps.
- README-only change; no action code touched.

Companion to tenstorrent/tt-metal#44023, which applies the same fix to the 6 existing callers in tt-metal.

## Test plan
- [ ] Render preview looks right (markdown)