### PR TITLE
Parse acceptance criteria from report JSON

### DIFF
--- a/.github/actions/collect_data/src/benchmark.py
+++ b/.github/actions/collect_data/src/benchmark.py
@@ -434,8 +434,8 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
         Processes acceptance criteria and creates CompleteBenchmarkRun object for it.
         """
         _ACCEPTANCE_CRITERIA_FIELDS = (
-            "acceptance_blockers", 
-            "acceptance_criteria_metadata", 
+            "acceptance_blockers",
+            "acceptance_criteria_metadata",
             "acceptance_summary_markdown",
         )
 

--- a/.github/actions/collect_data/src/benchmark.py
+++ b/.github/actions/collect_data/src/benchmark.py
@@ -255,18 +255,6 @@ class ForgeBenchmarkDataMapper(_BenchmarkDataMapper):
 
 
 class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
-    # Numeric encodings for acceptance_criteria fields. BenchmarkMeasurement.value
-    # is float-only, so PASS/FAIL strings and model-status tier names are mapped
-    # to floats. Pass/fail uses the same convention as accuracy_check (2=pass,
-    # 3=fail). Model status is an ordinal tier.
-    _ACCEPTANCE_PASS_FAIL = {"PASS": 2.0, "FAIL": 3.0}
-    _MODEL_STATUS_TIERS = {
-        "NON-FUNCTIONAL": 0.0,
-        "EXPERIMENTAL": 1.0,
-        "FUNCTIONAL": 2.0,
-        "COMPLETE": 3.0,
-    }
-
     def map_benchmark_data(self, pipeline, job_id, report_data, model_spec_data=None) -> CompleteBenchmarkRun | None:
         """
         Maps benchmark and evaluation data from the report to CompleteBenchmarkRun objects.
@@ -442,47 +430,35 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
         return results
 
     def _process_acceptance_criteria(self, pipeline, job, report_data, metadata=None, model_spec_data=None):
-        """Emit a CompleteBenchmarkRun for the report's acceptance_criteria fields.
-
-        Three measurements (step_name='acceptance_criteria'):
-            passed              ← report.acceptance_criteria (bool, 2=pass, 3=fail)
-            enforcement_result  ← report.acceptance_criteria_metadata.enforcement_result
-            model_status        ← report.acceptance_criteria_metadata.model_status
-                                  as an ordinal tier (NON-FUNCTIONAL=0, EXPERIMENTAL=1,
-                                  FUNCTIONAL=2, COMPLETE=3)
-
-        Unparseable or missing fields are skipped (the consumer sees the absence,
-        no sentinel value). Returns [] for older reports that have none of these.
         """
-        ac_metadata = report_data.get("acceptance_criteria_metadata") or {}
-        acceptance_pass = report_data.get("acceptance_criteria")
+        Processes acceptance criteria and creates CompleteBenchmarkRun object for it.
+        """
+        _ACCEPTANCE_CRITERIA_FIELDS = ("acceptance_blockers", "acceptance_criteria_metadata", "acceptance_summary_markdown")
 
-        encoded: Dict[str, float] = {}
+        acceptance_pass = report_data.get("acceptance_criteria")
+        encoded_measurements: Dict[str, float] = {}
 
         if isinstance(acceptance_pass, bool):
-            encoded["passed"] = 2.0 if acceptance_pass else 3.0
+            encoded_measurements["passed"] = 1.0 if acceptance_pass else 0.0
 
-        enforcement = ac_metadata.get("enforcement_result")
-        if isinstance(enforcement, str) and enforcement.upper() in self._ACCEPTANCE_PASS_FAIL:
-            encoded["enforcement_result"] = self._ACCEPTANCE_PASS_FAIL[enforcement.upper()]
-
-        model_status = ac_metadata.get("model_status")
-        if isinstance(model_status, str) and model_status.upper() in self._MODEL_STATUS_TIERS:
-            encoded["model_status"] = self._MODEL_STATUS_TIERS[model_status.upper()]
-
-        if not encoded:
+        if not encoded_measurements:
             return []
 
         measurements = self._create_measurements(
             job,
             "acceptance_criteria",
-            encoded,
-            list(encoded.keys()),
+            encoded_measurements,
+            list(encoded_measurements.keys()),
         )
         if not measurements:
             return []
 
-        md = metadata or {}
+        config_params = dict(model_spec_data) if model_spec_data else {}
+        for field in _ACCEPTANCE_CRITERIA_FIELDS:
+            value = report_data.get(field)
+            if value is not None:
+                config_params[field] = value
+
         return [
             self._create_complete_benchmark_run(
                 pipeline=pipeline,
@@ -490,10 +466,10 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
                 data=report_data,
                 run_type="acceptance_criteria",
                 measurements=measurements,
-                device_info=md.get("device"),
-                model_name=md.get("model_name"),
+                device_info=metadata.get("device"),
+                model_name=metadata.get("model_name"),
                 model_type=(model_spec_data.get("model_type") if model_spec_data else None),
-                config_params=model_spec_data,
+                config_params=config_params or None,
                 docker_image=(model_spec_data or {}).get("docker_image") or job.docker_image,
             )
         ]

--- a/.github/actions/collect_data/src/benchmark.py
+++ b/.github/actions/collect_data/src/benchmark.py
@@ -255,6 +255,18 @@ class ForgeBenchmarkDataMapper(_BenchmarkDataMapper):
 
 
 class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
+    # Numeric encodings for acceptance_criteria fields. BenchmarkMeasurement.value
+    # is float-only, so PASS/FAIL strings and model-status tier names are mapped
+    # to floats. Pass/fail uses the same convention as accuracy_check (2=pass,
+    # 3=fail). Model status is an ordinal tier.
+    _ACCEPTANCE_PASS_FAIL = {"PASS": 2.0, "FAIL": 3.0}
+    _MODEL_STATUS_TIERS = {
+        "NON-FUNCTIONAL": 0.0,
+        "EXPERIMENTAL": 1.0,
+        "FUNCTIONAL": 2.0,
+        "COMPLETE": 3.0,
+    }
+
     def map_benchmark_data(self, pipeline, job_id, report_data, model_spec_data=None) -> CompleteBenchmarkRun | None:
         """
         Maps benchmark and evaluation data from the report to CompleteBenchmarkRun objects.
@@ -287,7 +299,14 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
                 metadata,
                 model_spec_data,
             )
-            return benchmark_runs + benchmark_summary_runs + eval_runs
+            acceptance_runs = self._process_acceptance_criteria(
+                pipeline,
+                job,
+                report_data,
+                metadata,
+                model_spec_data,
+            )
+            return benchmark_runs + benchmark_summary_runs + eval_runs + acceptance_runs
         except ValidationError as e:
             failure_happened()
             logger.error(f"Validation error: {e}")
@@ -421,6 +440,63 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
                 )
             )
         return results
+
+    def _process_acceptance_criteria(self, pipeline, job, report_data, metadata=None, model_spec_data=None):
+        """Emit a CompleteBenchmarkRun for the report's acceptance_criteria fields.
+
+        Three measurements (step_name='acceptance_criteria'):
+            passed              ← report.acceptance_criteria (bool, 2=pass, 3=fail)
+            enforcement_result  ← report.acceptance_criteria_metadata.enforcement_result
+            model_status        ← report.acceptance_criteria_metadata.model_status
+                                  as an ordinal tier (NON-FUNCTIONAL=0, EXPERIMENTAL=1,
+                                  FUNCTIONAL=2, COMPLETE=3)
+
+        Unparseable or missing fields are skipped (the consumer sees the absence,
+        no sentinel value). Returns [] for older reports that have none of these.
+        """
+        ac_metadata = report_data.get("acceptance_criteria_metadata") or {}
+        acceptance_pass = report_data.get("acceptance_criteria")
+
+        encoded: Dict[str, float] = {}
+
+        if isinstance(acceptance_pass, bool):
+            encoded["passed"] = 2.0 if acceptance_pass else 3.0
+
+        enforcement = ac_metadata.get("enforcement_result")
+        if isinstance(enforcement, str) and enforcement.upper() in self._ACCEPTANCE_PASS_FAIL:
+            encoded["enforcement_result"] = self._ACCEPTANCE_PASS_FAIL[enforcement.upper()]
+
+        model_status = ac_metadata.get("model_status")
+        if isinstance(model_status, str) and model_status.upper() in self._MODEL_STATUS_TIERS:
+            encoded["model_status"] = self._MODEL_STATUS_TIERS[model_status.upper()]
+
+        if not encoded:
+            return []
+
+        measurements = self._create_measurements(
+            job,
+            "acceptance_criteria",
+            encoded,
+            list(encoded.keys()),
+        )
+        if not measurements:
+            return []
+
+        md = metadata or {}
+        return [
+            self._create_complete_benchmark_run(
+                pipeline=pipeline,
+                job=job,
+                data=report_data,
+                run_type="acceptance_criteria",
+                measurements=measurements,
+                device_info=md.get("device"),
+                model_name=md.get("model_name"),
+                model_type=(model_spec_data.get("model_type") if model_spec_data else None),
+                config_params=model_spec_data,
+                docker_image=(model_spec_data or {}).get("docker_image") or job.docker_image,
+            )
+        ]
 
     def _process_evals(self, pipeline, job, evals, metadata=None, model_spec_data=None):
         """

--- a/.github/actions/collect_data/src/benchmark.py
+++ b/.github/actions/collect_data/src/benchmark.py
@@ -433,7 +433,11 @@ class ShieldBenchmarkDataMapper(_BenchmarkDataMapper):
         """
         Processes acceptance criteria and creates CompleteBenchmarkRun object for it.
         """
-        _ACCEPTANCE_CRITERIA_FIELDS = ("acceptance_blockers", "acceptance_criteria_metadata", "acceptance_summary_markdown")
+        _ACCEPTANCE_CRITERIA_FIELDS = (
+            "acceptance_blockers", 
+            "acceptance_criteria_metadata", 
+            "acceptance_summary_markdown",
+        )
 
         acceptance_pass = report_data.get("acceptance_criteria")
         encoded_measurements: Dict[str, float] = {}

--- a/.github/actions/collect_data/test/test_benchmark_mapper.py
+++ b/.github/actions/collect_data/test/test_benchmark_mapper.py
@@ -777,52 +777,140 @@ def _acceptance_run(result):
     return runs[0]
 
 
-def test_process_acceptance_criteria_fail_functional(mapper, pipeline):
-    """FAIL + FUNCTIONAL tier mirrors a real failing release report."""
+# A realistic acceptance_criteria block as emitted by a Shield release report.
+_AC_BLOCKERS = ["latency above threshold", "accuracy regression"]
+_AC_METADATA = {"enforcement_result": "FAIL", "model_status": "FUNCTIONAL"}
+_AC_SUMMARY_MD = "## Acceptance summary\n- latency: FAIL\n- accuracy: FAIL"
+
+
+def test_process_acceptance_criteria_pass(mapper, pipeline):
     report_data = {
         "metadata": {"model_name": "Llama-3.2-1B-Instruct", "device": "t3k"},
-        "acceptance_criteria": False,
-        "acceptance_criteria_metadata": {
-            "enforcement_result": "FAIL",
-            "model_status": "FUNCTIONAL",
-        },
+        "acceptance_criteria": True,
     }
     run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
     assert run.ml_model_name == "Llama-3.2-1B-Instruct"
     assert run.device_info == {"device_name": "t3k"}
     by_name = {m.name: m.value for m in run.measurements}
-    assert by_name == {"passed": 3.0, "enforcement_result": 3.0, "model_status": 2.0}
+    assert by_name == {"passed": 1.0}
 
 
-def test_process_acceptance_criteria_pass_complete(mapper, pipeline):
-    """PASS + COMPLETE tier — different encoding path."""
-    report_data = {
-        "metadata": {"model_name": "m", "device": "d"},
-        "acceptance_criteria": True,
-        "acceptance_criteria_metadata": {
-            "enforcement_result": "PASS",
-            "model_status": "COMPLETE",
-        },
-    }
-    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
-    by_name = {m.name: m.value for m in run.measurements}
-    assert by_name == {"passed": 2.0, "enforcement_result": 2.0, "model_status": 3.0}
-
-
-def test_process_acceptance_criteria_unknown_value_is_skipped(mapper, pipeline):
-    """An unrecognised enforcement string is dropped rather than emitting a sentinel."""
+def test_process_acceptance_criteria_fail(mapper, pipeline):
     report_data = {
         "metadata": {"model_name": "m", "device": "d"},
         "acceptance_criteria": False,
-        "acceptance_criteria_metadata": {"enforcement_result": "SOMETHING_NEW"},
     }
     run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
-    names = {m.name for m in run.measurements}
-    assert names == {"passed"}  # enforcement_result is absent
+    by_name = {m.name: m.value for m in run.measurements}
+    assert by_name == {"passed": 0.0}
+
+
+def test_process_acceptance_criteria_non_bool_skips_run(mapper, pipeline):
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": "PASS",
+    }
+    result = mapper.map_benchmark_data(pipeline, 1, report_data)
+    assert [r for r in result if r.run_type == "acceptance_criteria"] == []
 
 
 def test_process_acceptance_criteria_absent_skips_run(mapper, pipeline):
-    """Old reports with no acceptance fields → no acceptance_criteria run emitted."""
     report_data = {"metadata": {"model_name": "m", "device": "d"}, "benchmarks": []}
     result = mapper.map_benchmark_data(pipeline, 1, report_data)
     assert [r for r in result if r.run_type == "acceptance_criteria"] == []
+
+
+def test_acceptance_config_fields_alone_do_not_emit_run(mapper, pipeline):
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_blockers": _AC_BLOCKERS,
+        "acceptance_criteria_metadata": _AC_METADATA,
+        "acceptance_summary_markdown": _AC_SUMMARY_MD,
+    }
+    result = mapper.map_benchmark_data(pipeline, 1, report_data)
+    assert [r for r in result if r.run_type == "acceptance_criteria"] == []
+
+
+def test_acceptance_config_params_includes_report_fields(mapper, pipeline):
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": False,
+        "acceptance_blockers": _AC_BLOCKERS,
+        "acceptance_criteria_metadata": _AC_METADATA,
+        "acceptance_summary_markdown": _AC_SUMMARY_MD,
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    assert run.config_params == {
+        "acceptance_blockers": _AC_BLOCKERS,
+        "acceptance_criteria_metadata": _AC_METADATA,
+        "acceptance_summary_markdown": _AC_SUMMARY_MD,
+    }
+
+
+def test_acceptance_config_params_merges_model_spec_and_report_fields(mapper, pipeline):
+    model_spec_data = {
+        "model_id": "test_model",
+        "model_type": "llm",
+        "docker_image": "spec_image",
+    }
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": True,
+        "acceptance_blockers": _AC_BLOCKERS,
+        "acceptance_criteria_metadata": _AC_METADATA,
+        "acceptance_summary_markdown": _AC_SUMMARY_MD,
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data, model_spec_data))
+    assert run.ml_model_type == "llm"
+    assert run.config_params == {
+        "model_id": "test_model",
+        "model_type": "llm",
+        "docker_image": "spec_image",
+        "acceptance_blockers": _AC_BLOCKERS,
+        "acceptance_criteria_metadata": _AC_METADATA,
+        "acceptance_summary_markdown": _AC_SUMMARY_MD,
+    }
+
+
+def test_acceptance_config_params_none_when_nothing_to_record(mapper, pipeline):
+    """With no model_spec_data and none of the acceptance_* fields, config_params is None."""
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": True,
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    assert run.config_params is None
+
+
+def test_acceptance_config_params_omits_absent_and_none_fields(mapper, pipeline):
+    """Only present, non-None acceptance_* fields land in config_params."""
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": True,
+        "acceptance_blockers": _AC_BLOCKERS,
+        "acceptance_criteria_metadata": None,  # explicit None is dropped
+        # acceptance_summary_markdown absent entirely
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    assert run.config_params == {"acceptance_blockers": _AC_BLOCKERS}
+
+
+def test_acceptance_config_params_preserves_empty_collections(mapper, pipeline):
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": True,
+        "acceptance_blockers": [],
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    assert run.config_params == {"acceptance_blockers": []}
+
+
+def test_acceptance_config_params_does_not_mutate_model_spec(mapper, pipeline):
+    model_spec_data = {"model_id": "test_model"}
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": True,
+        "acceptance_blockers": _AC_BLOCKERS,
+    }
+    mapper.map_benchmark_data(pipeline, 1, report_data, model_spec_data)
+    assert model_spec_data == {"model_id": "test_model"}

--- a/.github/actions/collect_data/test/test_benchmark_mapper.py
+++ b/.github/actions/collect_data/test/test_benchmark_mapper.py
@@ -766,3 +766,63 @@ def test_guidellm_skips_nan_inf(guidellm_mapper, guidellm_pipeline):
     assert "metrics_request_latency_successful_mean" not in by_name
     assert "metrics_request_latency_successful_max" not in by_name
     assert "metrics_request_latency_successful_min" not in by_name
+
+
+# --- acceptance_criteria tests ---
+
+
+def _acceptance_run(result):
+    runs = [r for r in result if r.run_type == "acceptance_criteria"]
+    assert len(runs) == 1
+    return runs[0]
+
+
+def test_process_acceptance_criteria_fail_functional(mapper, pipeline):
+    """FAIL + FUNCTIONAL tier mirrors a real failing release report."""
+    report_data = {
+        "metadata": {"model_name": "Llama-3.2-1B-Instruct", "device": "t3k"},
+        "acceptance_criteria": False,
+        "acceptance_criteria_metadata": {
+            "enforcement_result": "FAIL",
+            "model_status": "FUNCTIONAL",
+        },
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    assert run.ml_model_name == "Llama-3.2-1B-Instruct"
+    assert run.device_info == {"device_name": "t3k"}
+    by_name = {m.name: m.value for m in run.measurements}
+    assert by_name == {"passed": 3.0, "enforcement_result": 3.0, "model_status": 2.0}
+
+
+def test_process_acceptance_criteria_pass_complete(mapper, pipeline):
+    """PASS + COMPLETE tier — different encoding path."""
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": True,
+        "acceptance_criteria_metadata": {
+            "enforcement_result": "PASS",
+            "model_status": "COMPLETE",
+        },
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    by_name = {m.name: m.value for m in run.measurements}
+    assert by_name == {"passed": 2.0, "enforcement_result": 2.0, "model_status": 3.0}
+
+
+def test_process_acceptance_criteria_unknown_value_is_skipped(mapper, pipeline):
+    """An unrecognised enforcement string is dropped rather than emitting a sentinel."""
+    report_data = {
+        "metadata": {"model_name": "m", "device": "d"},
+        "acceptance_criteria": False,
+        "acceptance_criteria_metadata": {"enforcement_result": "SOMETHING_NEW"},
+    }
+    run = _acceptance_run(mapper.map_benchmark_data(pipeline, 1, report_data))
+    names = {m.name for m in run.measurements}
+    assert names == {"passed"}  # enforcement_result is absent
+
+
+def test_process_acceptance_criteria_absent_skips_run(mapper, pipeline):
+    """Old reports with no acceptance fields → no acceptance_criteria run emitted."""
+    report_data = {"metadata": {"model_name": "m", "device": "d"}, "benchmarks": []}
+    result = mapper.map_benchmark_data(pipeline, 1, report_data)
+    assert [r for r in result if r.run_type == "acceptance_criteria"] == []


### PR DESCRIPTION
This PR adds a new `_process_acceptance_criteria` method to `ShieldBenchmarkDataMapper`, wired into `map_benchmark_data`, that emits a dedicated `acceptance_criteria` run whenever a report contains a boolean `acceptance_criteria` field (encoded as a single passed measurement: 1.0 for pass, 0.0 for fail). The run's `config_params` merges any `model_spec_data` with three additional report fields — `acceptance_blockers`, `acceptance_criteria_metadata`, and `acceptance_summary_markdown`