### PR TITLE
ai-summary: don't capture adjacent test on bare FAILED line

### DIFF
--- a/.github/actions/ai_summary/tool/ai_job_summary/config/analysis.yaml
+++ b/.github/actions/ai_summary/tool/ai_job_summary/config/analysis.yaml
@@ -309,7 +309,7 @@ test_patterns:
     type: passed_failed
 
 failed_test_patterns:
-  - pattern: 'FAILED\s+(\S+::\S+)'
+  - pattern: 'FAILED[ \t]+(\S+::\S+)'
   - pattern: 'workflow:\s*(\w+),?\s*failed'
     prefix: "workflow:"
   - pattern: 'test_(\w+)\[.*\].*ConnectionError'

--- a/.github/actions/ai_summary/tool/ai_job_summary/tests/fixtures/log_samples/pytest_failed_adjacent_skip.txt
+++ b/.github/actions/ai_summary/tool/ai_job_summary/tests/fixtures/log_samples/pytest_failed_adjacent_skip.txt
@@ -1,0 +1,22 @@
+============================= test session starts ==============================
+models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_loudbox
+ERROR    | models.perf.device_perf_utils:check_device_perf:262 - AVG DEVICE KERNEL DURATION [ns] 8257406.25 is outside of expected range (8684162.65, 9221327.35)
+##[error]test_deepseek_v3_mla_perf_loudbox
+
+AssertionError: Some performance metrics are outside of expected range, see above for details.
+FAILED
+models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy SKIPPED
+
+=================================== FAILURES ===================================
+______________________ test_deepseek_v3_mla_perf_loudbox _______________________
+models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py:25: in test_deepseek_v3_mla_perf_loudbox
+    run_mla_perf_with_approximation(
+E   AssertionError: Some performance metrics are outside of expected range, see above for details.
+============================== slowest durations ===============================
+50.77s call     models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_loudbox
+0.19s setup    models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy
+0.00s call     models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy
+=========================== short test summary info ============================
+SKIPPED [1] models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py:38: This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)
+FAILED models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_loudbox - AssertionError: Some performance metrics are outside of expected range, see above for details.
+================== 1 failed, 1 skipped, 4 warnings in 51.30s ===================

--- a/.github/actions/ai_summary/tool/ai_job_summary/tests/test_extraction.py
+++ b/.github/actions/ai_summary/tool/ai_job_summary/tests/test_extraction.py
@@ -10,6 +10,7 @@ asserts the most meaningful extraction signals for each failure category.
 
 import pytest
 
+from ai_job_summary.config import load_config
 from ai_job_summary.extract import ExtractedLog, extract_log, merge_log_files
 
 from .conftest import FIXTURE_LOG_DIR as FIXTURE_DIR
@@ -791,3 +792,33 @@ class TestKilledProcessErrorSection:
             encoding="utf-8",
         )
         assert "killed" in _errors_text(extract_log(log))  # _errors_text lowercases
+
+
+# ── failed-test capture must not jump newlines onto an adjacent test ──────────
+
+
+class TestFailedTestAdjacentSkip:
+    """A bare ``FAILED`` status word (pytest -vvv) sits on its own line, with the
+    next test's result line right after it. The failed-test pattern must not bind
+    ``FAILED`` across the newline to that neighbour — here a SKIPPED test that
+    would otherwise be reported (and counted) as a failure.
+
+    Runs against the real bundled failed_test_patterns (load_config), since the
+    extractor only populates failed_tests when given the project's patterns."""
+
+    @pytest.fixture(scope="class")
+    def extracted(self):
+        config = load_config()
+        test_patterns = {
+            "test_result_patterns": config.get("test_patterns", []),
+            "failed_test_patterns": config.get("failed_test_patterns", []),
+        }
+        return extract_log(FIXTURE_DIR / "pytest_failed_adjacent_skip.txt", test_patterns=test_patterns)
+
+    def test_only_the_real_failure_captured(self, extracted):
+        assert extracted.failed_tests == [
+            "models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_loudbox"
+        ]
+
+    def test_skipped_neighbour_not_captured(self, extracted):
+        assert not any("galaxy" in t for t in extracted.failed_tests)


### PR DESCRIPTION
The failed_test_patterns rule `FAILED\s+(\S+::\S+)` used `\s`, which matches newlines. pytest -vvv prints a bare `FAILED` status word on its own line; the regex then bound it to the *next* line's node id. When that neighbour was another test's result (e.g. an adjacent SKIPPED test), it got reported and counted as a failure.

Constrain to same-line whitespace (`[ \t]+`) so the node id must follow `FAILED` on the same line. The real `short test summary info` line (`FAILED path::test - reason`) still matches.

Repro from run 26948207149 (bh_lb_DeepSeek_PREFILL_PERF): summary said "2 failed" listing test_deepseek_v3_mla_perf_galaxy (SKIPPED) alongside the real test_deepseek_v3_mla_perf_loudbox failure.